### PR TITLE
ci/pre commit/refactor hooks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -87,12 +87,13 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        hook_id:
+        hook_aliases:
           [
             trailing-whitespace,
             end-of-file-fixer,
             check-yaml,
             detect-private-key,
+            goimports-reviser
           ]
     steps:
       - name: Checkout code
@@ -101,7 +102,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
 
-      - name: Run [${{ matrix.hook_id }}]
+      - name: Run [${{ matrix.hook_aliases }}]
         uses: pre-commit/action@v3.0.0
         with:
-          extra_args: ${{ matrix.hook_id }} --all-files
+          extra_args: ${{ matrix.hook_aliases }} --all-files

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -96,11 +96,24 @@ jobs:
             goimports-reviser
           ]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
       - name: Install Python
         uses: actions/setup-python@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          # https://github.com/actions/setup-go#supported-version-syntax
+          # ex:
+          # - 1.18beta1 -> 1.18.0-beta.1
+          # - 1.18rc1 -> 1.18.0-rc.1
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Go tools
+        run: |
+          go install github.com/incu6us/goimports-reviser/v3@latest
+
+      - name: Checkout code
+        uses: actions/checkout@v3
 
       - name: Run [${{ matrix.hook_aliases }}]
         uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,8 +42,12 @@ repos:
     rev: v1.0.0-rc.1
     hooks:
       - id: go-mod-tidy
+        name: go-mod
+        alias: go-mod
         exclude: tools
       - id: go-fmt
+        name: go-fmt
+        alias: go-fmt
         exclude: tools
       - id: my-cmd
         name: goimports-reviser

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,8 @@ repos:
         exclude: tools
       - id: go-fmt
         exclude: tools
+      - id: my-cmd
+        name: goimports-reviser
+        alias: goimports-reviser
+        exclude: tools
+        args: [goimports-reviser, ./...]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
     rev: v2.1.1
     hooks:
       - id: conventional-pre-commit
+        name: conventional-commits
+        alias: conventional-commits
         stages: [commit-msg]
         args:
           [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
             chore,
             ci,
             deploy,
-            dev,
             docs,
             feat,
             fix,

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ docs.generate:
 	@cd docs && $(MAKE) --no-print-directory generate-uml
 
 .SILENT: tools.install
-tools.install: tools.download
+tools.install:
 	@go mod download
+	@cat tools/tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
 	@cd docs && $(MAKE) --no-print-directory install-tools
 
 _lint_vet:

--- a/internal/lock-manager/infra/provider/repository/iredis/client.go
+++ b/internal/lock-manager/infra/provider/repository/iredis/client.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/redis/go-redis/v9"
+
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/infra/provider"
 )
 

--- a/internal/lock-manager/infra/provider/repository/iredis/delete_if_token_matches.go
+++ b/internal/lock-manager/infra/provider/repository/iredis/delete_if_token_matches.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/redis/go-redis/v9"
+
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/infra/provider"
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/model"
 )

--- a/internal/lock-manager/infra/provider/repository/iredis/get.go
+++ b/internal/lock-manager/infra/provider/repository/iredis/get.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/redis/go-redis/v9"
+
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/infra/provider"
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/model"
 )

--- a/internal/lock-manager/infra/provider/repository/iredis/lock_storage.go
+++ b/internal/lock-manager/infra/provider/repository/iredis/lock_storage.go
@@ -3,6 +3,7 @@ package iredis
 import (
 	"github.com/go-logr/logr"
 	"github.com/redis/go-redis/v9"
+
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/infra/provider"
 )
 

--- a/internal/lock-manager/infra/provider/repository/iredis/main_test.go
+++ b/internal/lock-manager/infra/provider/repository/iredis/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ory/dockertest"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
+
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/infra/provider"
 	"github.com/ruslanSorokin/lock-manager/internal/lock-manager/infra/provider/repository/iredis"
 )


### PR DESCRIPTION
- ci(pre-commit:conventional-commits): remove `dev` type
- ci(pre-commit): add goimports-reviser hook
- ci(pre-commit): give explicit names to go hooks
- ci(Makefile): fix `tools.install` target
- style: run goimports-reviser
- ci(pre-commit:conventional-commits): give explicit name & alias
- ci(github:pre-commit): add goimports-reviser
